### PR TITLE
Capture websocket connection details

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ http://127.0.0.1:8485/live?sport=18
 
 http://127.0.0.1:8485/data
 
-4.Soccer Goal Line (GET)：
+4.Get websocket connection info(GET)：
+
+http://127.0.0.1:8485/wsinfo
+
+5.Soccer Goal Line (GET)：
 
 http://124.156.195.77:8365/b365/soccer/test/oneHd2allEv/C1-G15?lang=en
 
@@ -76,7 +80,11 @@ http://127.0.0.1:8485/live?sport=18
 
 http://127.0.0.1:8485/data
 
-4.足球大小球指数(GET)：
+4.获取websocket连接信息(GET)：
+
+http://127.0.0.1:8485/wsinfo
+
+5.足球大小球指数(GET)：
 
 http://124.156.195.77:8365/b365/soccer/test/oneHd2allEv/C1-G15
 

--- a/chrome_extention/js/background.js
+++ b/chrome_extention/js/background.js
@@ -1,6 +1,35 @@
 // Initialize default apiUrl in chrome.storage.local
 
 var cachedApiUrl = "http://127.0.0.1:8485/data";
+
+// Capture websocket handshake details and forward them to the API
+chrome.webRequest.onBeforeSendHeaders.addListener(
+  function(details) {
+    // only collect bet365 websocket connections
+    if (!details.url.includes('bet365')) return;
+
+    const headers = {};
+    let cookies = '';
+    if (details.requestHeaders) {
+      for (const h of details.requestHeaders) {
+        headers[h.name] = h.value;
+        if (h.name.toLowerCase() === 'cookie') {
+          cookies = h.value || '';
+        }
+      }
+    }
+
+    const info = { url: details.url, headers: headers, cookies: cookies };
+
+    fetch(cachedApiUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ws_info: info })
+    }).catch(err => console.error('Error sending ws_info', err));
+  },
+  { urls: ['<all_urls>'], types: ['websocket'] },
+  ['requestHeaders', 'extraHeaders']
+);
 chrome.runtime.onInstalled.addListener(() => {
   chrome.storage.local.get("apiUrl", (result) => {
     if (!result.apiUrl) {

--- a/chrome_extention/manifest.json
+++ b/chrome_extention/manifest.json
@@ -11,7 +11,7 @@
     "https://*/*"
   ],
   "permissions": [
-    "storage", "activeTab", "scripting", "background"
+    "storage", "activeTab", "scripting", "background", "webRequest"
   ],
   "background": {
     "service_worker": "js/background.js"

--- a/local_api.py
+++ b/local_api.py
@@ -6,6 +6,9 @@ from flask_cors import CORS
 from flask import Flask, request, jsonify
 app = Flask(__name__)
 
+# store websocket connection information
+WS_INFO = []
+
 
 # cn: 中文版365
 language = "cn"
@@ -265,13 +268,22 @@ def handle_data():
     """
     if request.method == 'POST':
         data = request.json
-        try:
-            data_parse(data.get("data", ""))
-        except Exception as e:
-            print(f"Error parsing data: {e}")
+        if 'ws_info' in data:
+            WS_INFO.append(data['ws_info'])
+        else:
+            try:
+                data_parse(data.get("data", ""))
+            except Exception as e:
+                print(f"Error parsing data: {e}")
         return "1"
     elif request.method == 'GET':
         return jsonify(DATA), 200
+
+
+@app.route('/wsinfo', methods=['GET'])
+def ws_info():
+    """Return captured websocket connection info."""
+    return jsonify(WS_INFO), 200
 
 
 


### PR DESCRIPTION
## Summary
- add websocket info capture via Chrome webRequest
- forward handshake data to API and store in local_api
- expose new `/wsinfo` endpoint and document usage

## Testing
- `python -m py_compile local_api.py`
- `python -m json.tool chrome_extention/manifest.json`

------
https://chatgpt.com/codex/tasks/task_e_6840728e29ac832791037ba33ac865ef